### PR TITLE
Query Object Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If your query object is based on another class, you can set the `associated_rela
 
 ### Model Generator
 
-Even, you could generate the query object when you create your rails models. To do that, you have to enable the query generators at your application config file adding the following line:
+To generate the query object when you create your rails models, enable the query generators at your application config file adding the following line:
 
 ```ruby
 # config/application.rb

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ And it will create your UserQuery object at `app/queries` folder. If you have se
 
 :warning: Rspec is the only test framework supported for now.
 
-If your query object is based on another class, you can set the `associated_to` attribute to automatically override the `associated_relation` method.
+If your query object is based on another class, you can set the `associated_relation` attribute to automatically override the `associated_relation` method.
 
     $ rails generate query CustomUser assoacited_to:User
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ And it will create your UserQuery object at `app/queries` folder. If you have se
 
 If your query object is based on another class, you can set the `associated_relation` attribute to automatically override the `associated_relation` method.
 
-    $ rails generate query CustomUser assoacited_to:User
+    $ rails generate query CustomUser associated_relation:User
 
 ### Model Generator
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ARQO (Active Record Query Objects) is a minimal gem that let you use Query Objec
   - [Setting up a query object](#setting-up-a-query-object)
   - [Deriving the model](#deriving-the-model)
   - [Chaining scopes](#chaining-scopes)
+  - [Generators](#generators)
 - [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,49 @@ And then you chain everything together and it will just work :)
 UserQuery.new.where.not(name: nil).active_last_week.not_deleted.order(:id)
 ```
 
+## Generators
+
+To create the query object we can use the rails generator tool. For that, we just run:
+
+    $ rails generate query User
+
+And it will create your UserQuery object at `app/queries` folder. If you have set Rspec as your test framework, the corresponding spec file will be also created at `spec/queries`.
+
+:warning: Rspec is the only test framework supported for now.
+
+If your query object is based on another class, you can set the `associated_to` attribute to automatically override the `associated_relation` method.
+
+    $ rails generate query CustomUser assoacited_to:User
+
+### Model Generator
+
+Even, you could generate the query object when you create your rails models. To do that, you have to enable the query generators at your application config file adding the following line:
+
+```ruby
+# config/application.rb
+
+module App
+  class Application < Rails::Application
+    ...
+
+    config.generators do |g|
+      ...
+      g.query true # Added line
+    end
+  end
+end
+```
+
+Now, if you run the model generator:
+
+    $ rails generate model User
+
+The query object and spec will be created as well as the model, migrations, test files, etc.
+
+Another alternative, it is to add the `--query` option at the end of the command:
+
+    $ rails generate model User --query
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/arqo.gemspec
+++ b/arqo.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', ['>= 4', '< 7']
 
+  spec.add_development_dependency 'ammeter', '~> 1.1'
   spec.add_development_dependency 'database_cleaner-active_record', '~> 1.8.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'reek', '~> 5.6.0'

--- a/lib/arqo.rb
+++ b/lib/arqo.rb
@@ -2,6 +2,7 @@
 
 require 'arqo/query'
 require 'arqo/version'
+require 'arqo/railtie' if defined?(Rails)
 
 module ARQO
   class Error < StandardError; end

--- a/lib/arqo.rb
+++ b/lib/arqo.rb
@@ -2,7 +2,7 @@
 
 require 'arqo/query'
 require 'arqo/version'
-require 'arqo/railtie' if defined?(Rails)
+require 'arqo/railtie'
 
 module ARQO
   class Error < StandardError; end

--- a/lib/arqo/railtie.rb
+++ b/lib/arqo/railtie.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails/railtie'
+
+module ActiveModel
+  class Railtie < Rails::Railtie
+    generators do |app|
+      Rails::Generators.configure! app.config.generators
+      require_relative '../generators/model_generator'
+    end
+  end
+end

--- a/lib/generators/arqo/named_base.rb
+++ b/lib/generators/arqo/named_base.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails/generators/named_base'
+
+module ARQO
+  module Generators
+    class NamedBase < Rails::Generators::NamedBase
+      argument :attributes, type: :array, default: [], banner: 'associated_to[:class_name]'
+
+      private
+
+      def associated_to
+        attributes.find { |attribute| attribute.name == 'associated_to' }&.type
+      end
+
+      def associated_relation
+        associated_to&.to_s&.classify
+      end
+
+      def factory
+        (associated_to || class_name)&.to_s&.underscore
+      end
+    end
+  end
+end

--- a/lib/generators/arqo/named_base.rb
+++ b/lib/generators/arqo/named_base.rb
@@ -5,16 +5,16 @@ require 'rails/generators/named_base'
 module ARQO
   module Generators
     class NamedBase < Rails::Generators::NamedBase
-      argument :attributes, type: :array, default: [], banner: 'associated_to[:class_name]'
+      argument :attributes, type: :array, default: [], banner: 'associated_relation[:class_name]'
 
       private
 
-      def associated_to
-        attributes.find { |attribute| attribute.name == 'associated_to' }&.type
+      def associated_relation
+        attributes.find { |attribute| attribute.name == 'associated_relation' }&.type
       end
 
-      def associated_relation
-        associated_to&.to_s&.classify
+      def associated_relation_class
+        associated_relation&.to_s&.classify
       end
 
       def factory

--- a/lib/generators/arqo/named_base.rb
+++ b/lib/generators/arqo/named_base.rb
@@ -16,10 +16,6 @@ module ARQO
       def associated_relation_class
         associated_relation&.to_s&.classify
       end
-
-      def factory
-        (associated_to || class_name)&.to_s&.underscore
-      end
     end
   end
 end

--- a/lib/generators/model_generator.rb
+++ b/lib/generators/model_generator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+require 'rails/generators/rails/model/model_generator'
+require_relative 'rails/query_generator'
+
+module Rails
+  module Generators
+    class ModelGenerator
+      hook_for :query, type: :boolean, default: false
+    end
+  end
+end

--- a/lib/generators/rails/USAGE
+++ b/lib/generators/rails/USAGE
@@ -1,12 +1,12 @@
 Usage:
-  rails generate query NAME [associated_to[:model]]
+  rails generate query NAME [associated_relation[:model]]
 
 Description:
     Generates a new ARQO query object at app/queries. Pass the generator name
     as an argument, either CamelCased or snake_cased, and an optional
-    attribute 'associated_to' as an argument.
+    attribute 'associated_relation' as an argument.
 
-    The 'associated_to' attribute expects an ActiveRecord class as value. This
+    The 'associated_relation' attribute expects an ActiveRecord class as value. This
     is useful for cases where you want to override the associated relation in
     the query object.
 
@@ -29,7 +29,7 @@ Example:
         Query Object:   app/queries/admin/account_query.rb
         Rspec:          spec/queries/admin/account_query.rb
 
-    `rails generate query Account associated_to:User`
+    `rails generate query Account associated_relation:User`
 
     Creates an account query object and the spec file including the
     specification of the `associated_relation` method.

--- a/lib/generators/rails/USAGE
+++ b/lib/generators/rails/USAGE
@@ -1,0 +1,38 @@
+Usage:
+  rails generate query NAME [associated_to[:model]]
+
+Description:
+    Generates a new ARQO query object at app/queries. Pass the generator name
+    as an argument, either CamelCased or snake_cased, and an optional
+    attribute 'associated_to' as an argument.
+
+    The 'associated_to' attribute expects an ActiveRecord class as value. This
+    is useful for cases where you want to override the associated relation in
+    the query object.
+
+    This generator invokes your configured ORM and test framework, which Active
+    Record and Rspec are the only ones supported at the moment.
+
+Example:
+    `rails generate query Account`
+
+    Creates a standard account query object and the spec file.
+
+        Query Object:   app/queries/account_query.rb
+        Rspec:          spec/queries/account_query.rb
+
+    `rails generate query Admin::Account`
+
+    Creates an account query object and the spec file following the namespace
+    location.
+
+        Query Object:   app/queries/admin/account_query.rb
+        Rspec:          spec/queries/admin/account_query.rb
+
+    `rails generate query Account associated_to:User`
+
+    Creates an account query object and the spec file including the
+    specification of the `associated_relation` method.
+
+        app/queries/account_query.rb
+        spec/queries/account_query.rb

--- a/lib/generators/rails/query_generator.rb
+++ b/lib/generators/rails/query_generator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../arqo/named_base'
+
+module Rails
+  module Generators
+    class QueryGenerator < ARQO::Generators::NamedBase
+      source_root File.expand_path('templates', __dir__)
+
+      check_class_collision suffix: 'Query'
+
+      hook_for :test_framework
+
+      def create_model_query
+        return if class_name.blank?
+
+        template_file = File.join('app/queries', class_path, "#{file_name}_query.rb")
+        template 'query.rb.erb', template_file
+      end
+    end
+  end
+end

--- a/lib/generators/rails/templates/query.rb.erb
+++ b/lib/generators/rails/templates/query.rb.erb
@@ -1,0 +1,15 @@
+<% module_namespacing do -%>
+class <%= class_name %>Query < ARQO::Query
+  module Scope
+    # Add <%= class_name %> scopes here
+  end
+<% if associated_relation -%>
+
+  private
+
+  def associated_relation
+    <%= associated_relation %> # you can also do something like <%= associated_relation %>.some_scope
+  end
+<% end -%>
+end
+<% end -%>

--- a/lib/generators/rails/templates/query.rb.erb
+++ b/lib/generators/rails/templates/query.rb.erb
@@ -8,7 +8,7 @@ class <%= class_name %>Query < ARQO::Query
   private
 
   def associated_relation
-    <%= associated_relation %> # you can also do something like <%= associated_relation %>.some_scope
+    <%= associated_relation_class %> # you can also do something like <%= associated_relation_class %>.some_scope
   end
 <% end -%>
 end

--- a/lib/generators/rspec/query_generator.rb
+++ b/lib/generators/rspec/query_generator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../arqo/named_base'
+
+module Rspec
+  module Generators
+    class QueryGenerator < ARQO::Generators::NamedBase
+      source_root File.expand_path('templates', __dir__)
+
+      def create_model_query_spec
+        template_file = File.join('spec/queries', class_path, "#{file_name}_query_spec.rb")
+        template 'query_spec.rb.erb', template_file
+      end
+    end
+  end
+end

--- a/lib/generators/rspec/templates/query_spec.rb.erb
+++ b/lib/generators/rspec/templates/query_spec.rb.erb
@@ -4,12 +4,6 @@ require 'rails_helper'
 RSpec.describe <%= class_name %>Query do
   subject(:query) { described_class.new }
 
-  describe '#all' do
-    let!(:<%= table_name %>) { create_list(:<%= factory %>, 3) }
-
-    it 'returns all <%= plural_name.humanize %>' do
-      expect(query.all).to match_array(<%= table_name %>)
-    end
-  end
+  pending 'add some query object tests here'
 end
 <% end -%>

--- a/lib/generators/rspec/templates/query_spec.rb.erb
+++ b/lib/generators/rspec/templates/query_spec.rb.erb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+<% module_namespacing do -%>
+RSpec.describe <%= class_name %>Query do
+  subject(:query) { described_class.new }
+
+  describe '#all' do
+    let!(:<%= table_name %>) { create_list(:<%= factory %>, 3) }
+
+    it 'returns all <%= plural_name.humanize %>' do
+      expect(query.all).to match_array(<%= table_name %>)
+    end
+  end
+end
+<% end -%>

--- a/spec/generators/model_generator_spec.rb
+++ b/spec/generators/model_generator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'generators/model_generator'
+
+RSpec.describe Rails::Generators::ModelGenerator do
+  destination File.expand_path('tmp', __dir__)
+
+  before { prepare_destination }
+  after(:all) { FileUtils.rm_rf destination_root }
+
+  describe 'the generated query object' do
+    subject { file('app/queries/your_model_query.rb') }
+
+    describe 'naming' do
+      before { run_generator %w[YourModel --query=true] }
+
+      it 'creates a file with the right name' do
+        expect(subject).to exist
+      end
+
+      it 'creates a class with the right name' do
+        expect(subject).to contain 'class YourModelQuery'
+      end
+    end
+  end
+
+  describe 'the generated query object spec' do
+    context 'with rspec as test_framework' do
+      describe 'naming' do
+        subject { file('spec/queries/your_model_query_spec.rb') }
+
+        before { run_generator %w[YourModel --query=true -t=rspec] }
+
+        it 'creates a spec file with the right name' do
+          expect(subject).to exist
+        end
+
+        it 'creates a spec class with the right name' do
+          expect(subject).to contain 'describe YourModelQuery'
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/query/query_generator_spec.rb
+++ b/spec/generators/query/query_generator_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'generators/rails/query_generator'
+
+RSpec.describe Rails::Generators::QueryGenerator do
+  destination File.expand_path('tmp', __dir__)
+
+  before { prepare_destination }
+  after(:all) { FileUtils.rm_rf destination_root }
+
+  describe 'the generated query object' do
+    subject { file('app/queries/your_model_query.rb') }
+
+    describe 'naming' do
+      before { run_generator %w[YourModel] }
+
+      it 'creates a file with the right name' do
+        expect(subject).to exist
+      end
+
+      it 'creates a class with the right name' do
+        expect(subject).to contain 'class YourModelQuery'
+      end
+    end
+
+    describe 'namespacing' do
+      subject { file('app/queries/your_namespace/your_model_query.rb') }
+
+      before { run_generator %w[YourNamespace::YourModel] }
+
+      it 'creates a file with the right name adn location' do
+        expect(subject).to exist
+      end
+
+      it 'creates a class with the right name' do
+        expect(subject).to contain 'class YourNamespace::YourModelQuery'
+      end
+    end
+
+    describe 'inheritance' do
+      before { run_generator %w[YourModel] }
+
+      it 'creates a class inheriting from ARQO::Query' do
+        expect(subject).to contain 'class YourModelQuery < ARQO::Query'
+      end
+    end
+
+    describe 'contents' do
+      context 'by default' do
+        before { run_generator %w[YourModel] }
+
+        it 'creates a module named Scope' do
+          expect(subject).to contain 'module Scope'
+        end
+      end
+
+      context 'with associated_to attribute' do
+        context 'when attribute type is CamelCased value' do
+          before { run_generator %w[YourModel associated_to:MainModel] }
+
+          it 'creates a method named associated_relation' do
+            expect(subject).to have_method(:associated_relation).containing('MainModel')
+          end
+        end
+
+        context 'when attribute type is snake_cased value' do
+          before { run_generator %w[YourModel associated_to:main_model] }
+
+          it 'creates a method named associated_relation' do
+            expect(subject).to have_method(:associated_relation).containing('MainModel')
+          end
+        end
+      end
+    end
+  end
+
+  describe 'the generated query object spec' do
+    context 'with rspec as test_framework' do
+      describe 'naming' do
+        subject { file('spec/queries/your_model_query_spec.rb') }
+
+        before { run_generator %w[YourModel -t=rspec] }
+
+        it 'creates a spec file with the right name' do
+          expect(subject).to exist
+        end
+
+        it 'creates a spec class with the right name' do
+          expect(subject).to contain 'describe YourModelQuery'
+        end
+      end
+
+      describe 'namespacing' do
+        subject { file('spec/queries/your_namespace/your_model_query_spec.rb') }
+
+        before { run_generator %w[YourNamespace::YourModel -t=rspec] }
+
+        it 'creates a spec file with the right name adn location' do
+          expect(subject).to exist
+        end
+
+        it 'creates a spec class with the right name' do
+          expect(subject).to contain 'describe YourNamespace::YourModelQuery'
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/query/query_generator_spec.rb
+++ b/spec/generators/query/query_generator_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe Rails::Generators::QueryGenerator do
         end
       end
 
-      context 'with associated_to attribute' do
+      context 'with associated_relation attribute' do
         context 'when attribute type is CamelCased value' do
-          before { run_generator %w[YourModel associated_to:MainModel] }
+          before { run_generator %w[YourModel associated_relation:MainModel] }
 
           it 'creates a method named associated_relation' do
             expect(subject).to have_method(:associated_relation).containing('MainModel')
@@ -64,7 +64,7 @@ RSpec.describe Rails::Generators::QueryGenerator do
         end
 
         context 'when attribute type is snake_cased value' do
-          before { run_generator %w[YourModel associated_to:main_model] }
+          before { run_generator %w[YourModel associated_relation:main_model] }
 
           it 'creates a method named associated_relation' do
             expect(subject).to have_method(:associated_relation).containing('MainModel')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'bundler/setup'
 require 'simplecov'
 require 'active_record'
 require 'database_cleaner/active_record'
+require 'action_controller/railtie'
+require 'ammeter/init'
 
 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This PR adds some generators described at #4. 

With the introduced changes, the devs will be able to create the query object definition and spec running the command `$ rails g query model_name`. Also, they would be able to create it automatically when run `$ rails g model model_name` with the appropriated configuration (mentioned in the readme file).

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.
Thanks for contributing to this project! -->

I added a new dev dependency [Ammeter](https://github.com/alexrothenberg/ammeter/) because it's useful to test generators since it provides some matchers and helpers to write tests. Although it wasn't updated recently, it has a good reputation since some important gems use it, for example [rspec-rails](https://github.com/rspec/rspec-rails).
