### PR TITLE
Increase maximum supported version of activerecord

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    - name: Update rubygems when testing with Ruby 2.7.x
-      if: startsWith(matrix.ruby_version, '2.7')
+    - name: Update rubygems when testing with Ruby 2.4.x
+      if: startsWith(matrix.ruby_version, '2.4')
       run: |
         gem update --system --no-document
     - name: Before build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_7.0.0.gemfile, rails_master.gemfile]
-        ruby_version: [2.4, 2.5, 2.6, 2.7, 3.0]
+        gemfile: [rails_4.0.0, rails_5.0.0, rails_5.2.3, rails_6.0.0, rails_7.0.0, rails_master]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0']
         exclude:
           - gemfile: rails_master.gemfile
-            ruby_version: 2.4.x
+            ruby_version: 2.4
           - gemfile: rails_master.gemfile
-            ruby_version: 2.5.x
+            ruby_version: 2.5
           - gemfile: rails_master.gemfile
-            ruby_version: 2.6.x
+            ruby_version: 2.6
           - gemfile: rails_7.0.0.gemfile
-            ruby_version: 2.4.x
+            ruby_version: 2.4
           - gemfile: rails_7.0.0.gemfile
-            ruby_version: 2.5.x
+            ruby_version: 2.5
           - gemfile: rails_7.0.0.gemfile
-            ruby_version: 2.6.x
+            ruby_version: 2.6
           - gemfile: rails_6.0.0.gemfile
-            ruby_version: 2.4.x
+            ruby_version: 2.4
+    env:
+      BUNDLE_GEMFILE: spec/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby_version }}
-    - name: Update rubygems when testing with Ruby 2.4.x
+        ruby-version: ${{ matrix.ruby }}
+    - name: Update rubygems when testing with Ruby 2.4
       if: startsWith(matrix.ruby_version, '2.4')
       run: |
         gem update --system --no-document
@@ -46,7 +48,7 @@ jobs:
       run: |
         gem install bundler:1.17.3
         bundle _1.17.3_ update
-        bundle _1.17.3_ install --gemfile spec/gemfiles/${{ matrix.gemfile }} --jobs 4 --retry 3
+        bundle _1.17.3_ install --gemfile spec/gemfiles/${{ matrix.gemfile }}.gemfile --jobs 4 --retry 3
         bundle _1.17.3_ exec rake code_analysis
         bundle _1.17.3_ exec rspec
     - name: Report to CodeClimate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_7.0.0.gemfile, rails_master.gemfile]
-        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x, 3.0.x]
+        ruby_version: [2.4, 2.5, 2.6, 2.7, 3.0]
         exclude:
           - gemfile: rails_master.gemfile
             ruby_version: 2.4.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_master.gemfile]
-        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
+        gemfile: [rails_4.0.0.gemfile, rails_5.0.0.gemfile, rails_5.2.3.gemfile, rails_6.0.0.gemfile, rails_7.0.0.gemfile, rails_master.gemfile]
+        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x, 3.0.x]
         exclude:
           - gemfile: rails_master.gemfile
-            ruby_version: 2.4.x
-          - gemfile: rails_6.0.0.gemfile
-            ruby_version: 2.4.x
+            ruby_version: 2.7.x
+          - gemfile: rails_7.0.0.gemfile
+            ruby_version: 2.7.x
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    - name: Update rubygems when testing with Ruby 2.4.x
-      if: startsWith(matrix.ruby_version, '2.4')
+    - name: Update rubygems when testing with Ruby 2.7.x
+      if: startsWith(matrix.ruby_version, '2.7')
       run: |
         gem update --system --no-document
     - name: Before build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,19 @@ jobs:
         ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x, 3.0.x]
         exclude:
           - gemfile: rails_master.gemfile
-            ruby_version: 2.7.x
+            ruby_version: 2.4.x
+          - gemfile: rails_master.gemfile
+            ruby_version: 2.5.x
+          - gemfile: rails_master.gemfile
+            ruby_version: 2.6.x
           - gemfile: rails_7.0.0.gemfile
-            ruby_version: 2.7.x
+            ruby_version: 2.4.x
+          - gemfile: rails_7.0.0.gemfile
+            ruby_version: 2.5.x
+          - gemfile: rails_7.0.0.gemfile
+            ruby_version: 2.6.x
+          - gemfile: rails_6.0.0.gemfile
+            ruby_version: 2.4.x
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/arqo.gemspec
+++ b/arqo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['LICENSE.txt', 'README.md', 'lib/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ['>= 4', '< 7']
+  spec.add_dependency 'activerecord', ['>= 4', '< 8']
 
   spec.add_development_dependency 'ammeter', '~> 1.1'
   spec.add_development_dependency 'database_cleaner-active_record', '~> 1.8.0'

--- a/lib/arqo/version.rb
+++ b/lib/arqo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ARQO
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/gemfiles/rails_7.0.0.gemfile
+++ b/spec/gemfiles/rails_7.0.0.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../..'
+
+gem 'rails', '~> 7.0.0'


### PR DESCRIPTION
### Summary

Currently this gem does not support rails 7. This PR adds support for activerecord 7.x

### Other Information

Error appearing when trying to add gem in a rails 7 project:
<img width="615" alt="Screen Shot 2021-12-30 at 10 02 19" src="https://user-images.githubusercontent.com/9309458/147755141-becb08ae-0b9a-459c-ad33-88169529712a.png">

