### PR TITLE
Fixes #18 - rails generator not working

### DIFF
--- a/lib/arqo/railtie.rb
+++ b/lib/arqo/railtie.rb
@@ -2,7 +2,7 @@
 
 require 'rails/railtie'
 
-module ActiveModel
+module ARQO
   class Railtie < Rails::Railtie
     generators do |app|
       Rails::Generators.configure! app.config.generators


### PR DESCRIPTION
Fixes #18 by using the correct namespace. Probably ActiveModel was overriding that same class.